### PR TITLE
Removed extra margin below nested bullets

### DIFF
--- a/themes/style/datastax.less
+++ b/themes/style/datastax.less
@@ -116,6 +116,8 @@ h5 {.font-size(2.6); .line-height(3.5);}
   // https://github.com/datastax-training/curriculum/issues/176
   // are not displayed as they cause unecessary spacing
   ul li p:last-child { display: none; }
+  // Indented items have a different bullet for more clarity
+  ul li ul li { list-style-type:circle; }
 
   // Images
   .image, .imageblock {

--- a/themes/style/datastax.less
+++ b/themes/style/datastax.less
@@ -137,6 +137,14 @@ h5 {.font-size(2.6); .line-height(3.5);}
     &.left {margin: .5em auto .5em 0; display: inline-block; padding: .5em;}
     &.right {margin: .5em 0 .5em auto; display: inline-block; padding: .5em;}
   }
+
+  // Code block currently has no margin which looks a little crappy
+  .listingblock {
+    margin-top: 0.25em;
+    margin-bottom: 0.5em;
+  }
+
+
   // Slide Notes
   .notes {position:absolute;z-index:1000;background: @blue90;color: @white;width: 100vw;height: 100vh;top: 0px;left: 0px;padding: 100px;.font-size(5); .border-box; overflow: scroll;
     li {

--- a/themes/style/datastax.less
+++ b/themes/style/datastax.less
@@ -108,7 +108,7 @@ h5 {.font-size(2.6); .line-height(3.5);}
   // List Items with cool node icons
   ul {margin: .5em .5em 1em 1.5em;
     li {.font-size(3.5);  list-style-type: disc; list-style-position: outside;
-      ul {margin: .5em .5em 1em 1.5em;}
+      ul {margin: .5em .5em 0 1.5em;}
     }
   }
 
@@ -318,3 +318,4 @@ a:hover, a:focus {
 
 // Hide these things from other themes
 .deck-header-summit, .flex-element-summit {display: none;}
+

--- a/themes/style/datastax.less
+++ b/themes/style/datastax.less
@@ -115,9 +115,10 @@ h5 {.font-size(2.6); .line-height(3.5);}
   // Ensure that trailing redundant paragraphs as per:
   // https://github.com/datastax-training/curriculum/issues/176
   // are not displayed as they cause unecessary spacing
+  ul li p { margin: 0; }
   ul li p:last-child { display: none; }
   // Indented items have a different bullet for more clarity
-  ul li ul li { list-style-type:circle; }
+  ul li ul li { list-style-type:circle; padding: 0; }
 
   // Images
   .image, .imageblock {

--- a/themes/style/datastax.less
+++ b/themes/style/datastax.less
@@ -112,6 +112,11 @@ h5 {.font-size(2.6); .line-height(3.5);}
     }
   }
 
+  // Ensure that trailing redundant paragraphs as per:
+  // https://github.com/datastax-training/curriculum/issues/176
+  // are not displayed as they cause unecessary spacing
+  ul li p:last-child { display: none; }
+
   // Images
   .image, .imageblock {
     img {


### PR DESCRIPTION
The following style in datastax.less (in conjunction with #176) causes v.large margins to be inserted underneath nested list items. This looks a bit clunky in most cases and also has the side effect of causing unnecessary overflow.

example:
![screen shot 2016-02-10 at 11 17 27](https://cloud.githubusercontent.com/assets/10423360/12945893/6d92b168-cfe8-11e5-9f27-5f8c9195b710.png)

In order to rectify this it would be good to reduce the lower margin
Removing the unnecessary paragraphs and setting the lower margin to 0 results in the following output:
![screen shot 2016-02-10 at 11 23 55](https://cloud.githubusercontent.com/assets/10423360/12945954/d10e509e-cfe8-11e5-9368-460998b81eb0.png)

Which IMHO opinion looks fine although it might be good to have a different bullet icon for nested for clarity?
